### PR TITLE
Improve worker to show HTML form

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ compatibility_date = "<YYYY-MM-DD>"
 ```
 
 2. Deploy the worker with `npx wrangler deploy`.
-3. Once deployed, call the worker with a `url` query parameter pointing to
-   the TikTok video you want to download.
+3. Once deployed you can simply open the worker URL in your browser. A small
+   HTML form will let you paste a TikTok link and start the download. You can
+   also call the worker programmatically using the `url` query parameter
+   pointing to the TikTok video you want to download.
 
 Example request:
 

--- a/worker.js
+++ b/worker.js
@@ -3,9 +3,48 @@ export default {
     const { searchParams } = new URL(request.url);
     const url = searchParams.get('url');
     if (!url) {
-      return new Response(JSON.stringify({ error: 'Missing url parameter' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+      const html = `<!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="UTF-8" />
+          <title>TikTok Downloader</title>
+          <style>
+            body { font-family: Arial, sans-serif; padding: 2rem; }
+            #status { color: red; margin-top: 1rem; }
+          </style>
+        </head>
+        <body>
+          <h1>TikTok Downloader</h1>
+          <input type="text" id="url" size="50" placeholder="Enter TikTok link" />
+          <button id="download">Get Download Link</button>
+          <p id="status"></p>
+          <script>
+            const btn = document.getElementById('download');
+            const status = document.getElementById('status');
+            btn.addEventListener('click', async () => {
+              const link = document.getElementById('url').value.trim();
+              if (!link) {
+                status.textContent = 'Please enter a TikTok link';
+                return;
+              }
+              status.textContent = 'Fetching...';
+              try {
+                const res = await fetch('?url=' + encodeURIComponent(link));
+                const data = await res.json();
+                if (data.download) {
+                  window.location = data.download;
+                } else {
+                  status.textContent = data.error || 'Unexpected response';
+                }
+              } catch (err) {
+                status.textContent = err.message;
+              }
+            });
+          </script>
+        </body>
+      </html>`;
+      return new Response(html, {
+        headers: { 'Content-Type': 'text/html;charset=UTF-8' },
       });
     }
     try {


### PR DESCRIPTION
## Summary
- show an HTML input form when visiting the worker without parameters
- document the HTML interface in the README

## Testing
- `python -m py_compile tiktok_downloader.py`
- `node --check worker.js`


------
https://chatgpt.com/codex/tasks/task_e_684642654fec832cb8f41fead9760142